### PR TITLE
Hide the invokedynamic warning about StringConcatFactory

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
@@ -194,6 +194,8 @@ class AsmClassRemapper extends ClassRemapper {
 			if (isJavaLambdaMetafactory(bsm)) {
 				assert desc.endsWith(";");
 				return new Handle(Opcodes.H_INVOKEINTERFACE, desc.substring(desc.lastIndexOf(')') + 2, desc.length() - 1), name, ((Type) bsmArgs[0]).getDescriptor(), true);
+			} else if (isJavaStringConcatFactory(bsm)) {
+				return null;
 			} else {
 				System.out.printf("unknown invokedynamic bsm: %s/%s%s (tag=%d iif=%b)%n", bsm.getOwner(), bsm.getName(), bsm.getDesc(), bsm.getTag(), bsm.isInterface());
 
@@ -208,6 +210,16 @@ class AsmClassRemapper extends ClassRemapper {
 							&& bsm.getDesc().equals("(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;")
 							|| bsm.getName().equals("altMetafactory")
 							&& bsm.getDesc().equals("(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;"))
+					&& !bsm.isInterface();
+		}
+
+		private static boolean isJavaStringConcatFactory(Handle bsm) {
+			return bsm.getTag() == Opcodes.H_INVOKESTATIC
+					&& bsm.getOwner().equals("java/lang/invoke/StringConcatFactory")
+					&& (bsm.getName().equals("makeConcat")
+							&& bsm.getDesc().equals("(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;")
+							|| bsm.getName().equals("makeConcatWithConstants")
+							&& bsm.getDesc().equals("(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;"))
 					&& !bsm.isInterface();
 		}
 


### PR DESCRIPTION
Since Java 9, String concatenation is by default done using an invokedynamic instruction that references StringConcatFactory as the bootstrap method. This makes TR aware of that method, since Minecraft does not make use of the javac flag to disable this.